### PR TITLE
Change python to python3

### DIFF
--- a/format-objc-file-dry-run.sh
+++ b/format-objc-file-dry-run.sh
@@ -14,14 +14,14 @@ if [ "$line" == "#pragma Formatter Exempt" -o "$line" == "// MARK: Formatter Exe
 fi
 
 cat "$1" | \
-python "$DIR"/custom/LiteralSymbolSpacer.py | \
-python "$DIR"/custom/InlineConstructorOnSingleLine.py | \
-python "$DIR"/custom/MacroSemicolonAppender.py | \
-#python "$DIR"/custom/DoubleNewlineInserter.py | \
+python3 "$DIR"/custom/LiteralSymbolSpacer.py | \
+python3 "$DIR"/custom/InlineConstructorOnSingleLine.py | \
+python3 "$DIR"/custom/MacroSemicolonAppender.py | \
+#python3 "$DIR"/custom/DoubleNewlineInserter.py | \
 "$DIR"/bin/clang-format-3.8-custom -style=file | \
-#python "$DIR"/custom/GenericCategoryLinebreakIndentation.py | \
-python "$DIR"/custom/ParameterAfterBlockNewline.py | \
-python "$DIR"/custom/HasIncludeSpaceRemover.py | \
-python "$DIR"/custom/NewLineAtEndOfFileInserter.py | \
-python "$DIR"/custom/RemoveVoidBlockDeclaration.py | \
-python "$DIR"/custom/RemoveAPIAvailableSemicolon.py
+#python3 "$DIR"/custom/GenericCategoryLinebreakIndentation.py | \
+python3 "$DIR"/custom/ParameterAfterBlockNewline.py | \
+python3 "$DIR"/custom/HasIncludeSpaceRemover.py | \
+python3 "$DIR"/custom/NewLineAtEndOfFileInserter.py | \
+python3 "$DIR"/custom/RemoveVoidBlockDeclaration.py | \
+python3 "$DIR"/custom/RemoveAPIAvailableSemicolon.py

--- a/format-objc-file.sh
+++ b/format-objc-file.sh
@@ -18,25 +18,25 @@ line="$(head -1 "$1" | xargs)"
 [ "$line" == "#pragma Formatter Exempt" -o "$line" == "// MARK: Formatter Exempt" ] && exit 0
 
 # Fix an edge case with array / dictionary literals that confuses clang-format
-python "$DIR"/custom/LiteralSymbolSpacer.py "$1"
+python3 "$DIR"/custom/LiteralSymbolSpacer.py "$1"
 # The formatter gets confused by C++ inline constructors that are broken onto multiple lines
-python "$DIR"/custom/InlineConstructorOnSingleLine.py "$1"
+python3 "$DIR"/custom/InlineConstructorOnSingleLine.py "$1"
 # Add a semicolon at the end of simple macros
-python "$DIR"/custom/MacroSemicolonAppender.py "$1"
+python3 "$DIR"/custom/MacroSemicolonAppender.py "$1"
 # Add an extra newline before @implementation and @interface
-#python "$DIR"/custom/DoubleNewlineInserter.py "$1"
+#python3 "$DIR"/custom/DoubleNewlineInserter.py "$1"
 
 # Run clang-format
 "$DIR"/bin/clang-format-3.8-custom -i -style=file "$1" ;
 # Fix an issue with clang-format getting confused by categories with generic expressions.
-#python "$DIR"/custom/GenericCategoryLinebreakIndentation.py "$1"
+#python3 "$DIR"/custom/GenericCategoryLinebreakIndentation.py "$1"
 # Fix an issue with clang-format breaking up a lone parameter onto a newline after a block literal argument.
-python "$DIR"/custom/ParameterAfterBlockNewline.py "$1"
+python3 "$DIR"/custom/ParameterAfterBlockNewline.py "$1"
 # Fix an issue with clang-format inserting spaces in a preprocessor macro.
-python "$DIR"/custom/HasIncludeSpaceRemover.py "$1"
+python3 "$DIR"/custom/HasIncludeSpaceRemover.py "$1"
 # Add a newline at the end of the file
-python "$DIR"/custom/NewLineAtEndOfFileInserter.py "$1"
+python3 "$DIR"/custom/NewLineAtEndOfFileInserter.py "$1"
 # Convert "^(void) {" to "^{" in block declarations
-python "$DIR"/custom/RemoveVoidBlockDeclaration.py "$1"
+python3 "$DIR"/custom/RemoveVoidBlockDeclaration.py "$1"
 # Remove trailing semicolon from API_AVAILABLE macros
-python "$DIR"/custom/RemoveAPIAvailableSemicolon.py "$1"
+python3 "$DIR"/custom/RemoveAPIAvailableSemicolon.py "$1"


### PR DESCRIPTION
Was having issues running spacecommander through Sourcetree after updating to macOS 12.3.1 (and installing Python3 through Brew), ever though I could call spacecommander manually from the Terminal.

Looks like Sourcetree wasn't looking at the PATH variable directly.
Changing calls from `python` to `python3` seems to do the trick, not needing access to PATH.

Will update refeferences in `fantastical`, `cardhop`, `flexibitskit`, and `fantasticalparse `.